### PR TITLE
Allow for error objects to be properly printed

### DIFF
--- a/Logger.js
+++ b/Logger.js
@@ -57,7 +57,7 @@ function handleJson(data) {
   let processedData = ''
   // Try to prettify any JSON passed in
   if (typeof data == 'object') {
-    processedData = indentJson(JSON.stringify(data, null, 2))
+    processedData = indentJson(JSON.stringify(data, objectifyError, 2))
   } else {
     // If data is a string, see if it's stringified json and prettify it
     try {
@@ -69,8 +69,23 @@ function handleJson(data) {
   return processedData
 }
 
+// This creates an object from an error that can be stringified.
+// If it's not an error, return original value. Stack overflow FTW.
+function objectifyError(key, value) {
+  if (value instanceof Error) {
+    let error = {}
+    Object.getOwnPropertyNames(value).forEach((key) => {
+      error[key] = value[key]
+    })
+    return error
+  }
+  return value
+}
+
 function indentJson(jsonString) {
   let splitIndented = []
+  // Stringification escapes new line characters. We set them back so stack traces are legible
+  jsonString = jsonString.split('\\n').join('\n')
   jsonString.split('\n').forEach((line) => { splitIndented.push(`\t${line}`) })
   return splitIndented.join('\n')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orphaneater/frill-free-logger",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Basic dependency free logging to files and console",
   "main": "index.js",
   "scripts": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,6 +37,11 @@ describe('Log output', () => {
       lumberJack.logInfo('z', 'not even json')
       sinon.assert.calledWith(log, sinon.match('\tnot even json'))
     })
+    it('will objectify, stringify and prettify an error object', () => {
+      lumberJack.logError('err', new Error('I have made a huge mistake'))
+      const lineCount = log.getCall(0).firstArg.split('\n').length
+      assert(lineCount > 6, `Expected there to be more than 6 lines in the log output, but there were only ${lineCount}`)
+    })
   })
   describe('zero settings', () => {
     let lumberJill = new Logger()


### PR DESCRIPTION
Fixes an issue where error objects being passed to the data parameter would swallow the error and prevent the pandemic from ending.